### PR TITLE
Branche pour la correction du TP3 avec Molecule

### DIFF
--- a/roles/flaskapp/.yamllint
+++ b/roles/flaskapp/.yamllint
@@ -1,0 +1,33 @@
+---
+# Based on ansible-lint config
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  colons:
+    max-spaces-after: -1
+    level: error
+  commas:
+    max-spaces-after: -1
+    level: error
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    max: 3
+    level: error
+  hyphens:
+    level: error
+  indentation: disable
+  key-duplicates: enable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines:
+    type: unix
+  trailing-spaces: disable
+  truthy: disable

--- a/roles/flaskapp/handlers/main.yml
+++ b/roles/flaskapp/handlers/main.yml
@@ -2,3 +2,9 @@
   systemd:
     name: nginx
     state: reloaded
+
+- name: start systemd app service
+  systemd:
+    name: "{{ template_out.dest | basename }}"
+    state: restarted
+    enabled: yes

--- a/roles/flaskapp/meta/main.yml
+++ b/roles/flaskapp/meta/main.yml
@@ -2,7 +2,7 @@
 dependencies: []
 
 galaxy_info:
-  author: <name>
+  author: author_example
   description: Install multiple instances of flask apps on linux with nginx
   license: "license (BSD, MIT)"
   min_ansible_version: 2.8

--- a/roles/flaskapp/molecule/default/converge.yml
+++ b/roles/flaskapp/molecule/default/converge.yml
@@ -1,0 +1,7 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: "Include flaskapp"
+      include_role:
+        name: "flaskapp"

--- a/roles/flaskapp/molecule/default/molecule.yml
+++ b/roles/flaskapp/molecule/default/molecule.yml
@@ -1,0 +1,13 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: instance
+    image: quay.io/centos/centos:stream8
+    pre_build_image: true
+provisioner:
+  name: ansible
+verifier:
+  name: ansible

--- a/roles/flaskapp/molecule/default/molecule.yml
+++ b/roles/flaskapp/molecule/default/molecule.yml
@@ -5,7 +5,7 @@ driver:
   name: docker
 platforms:
   - name: instance
-    image: quay.io/centos/centos:stream8
+    image: debian:bullseye
     pre_build_image: true
 provisioner:
   name: ansible

--- a/roles/flaskapp/molecule/default/molecule.yml
+++ b/roles/flaskapp/molecule/default/molecule.yml
@@ -5,8 +5,12 @@ driver:
   name: docker
 platforms:
   - name: instance
-    image: debian:bullseye
+    image: geerlingguy/docker-debian11-ansible
     pre_build_image: true
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+     - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
 provisioner:
   name: ansible
 verifier:

--- a/roles/flaskapp/molecule/default/prepare.yml
+++ b/roles/flaskapp/molecule/default/prepare.yml
@@ -1,0 +1,6 @@
+- hosts: all
+  remote_user: root
+  gather_facts: false
+  tasks:
+   - name: Install Python
+     raw: apt -y update && apt install -y python3

--- a/roles/flaskapp/molecule/default/verify.yml
+++ b/roles/flaskapp/molecule/default/verify.yml
@@ -1,0 +1,10 @@
+---
+# This is an example playbook to execute Ansible tests.
+
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+  - name: Example assertion
+    assert:
+      that: true

--- a/roles/flaskapp/molecule/default/verify.yml
+++ b/roles/flaskapp/molecule/default/verify.yml
@@ -8,3 +8,17 @@
   - name: Example assertion
     assert:
       that: true
+  - name: Check the default app is running
+    uri:
+      headers:
+        Host: hello.test
+      url: http://localhost/
+      return_content: yes
+    register: app_return
+  - name: debug default app return
+    debug:
+      var: app_return
+  - name: Assert default app return
+    assert:
+      that:
+        - "'<h1>Hello from helloworld on server instance!</h1>' in app_return.content"

--- a/roles/flaskapp/tasks/deploy_app_tasks.yml
+++ b/roles/flaskapp/tasks/deploy_app_tasks.yml
@@ -48,12 +48,8 @@
   template:
     src: app.service.j2
     dest: /etc/systemd/system/{{ app.name }}.service
-
-- name: start systemd app service
-  systemd:
-    name: "{{ app.name }}.service"
-    state: restarted
-    enabled: yes
+  notify: start systemd app service
+  register: template_out
 
 - name: template nginx site config
   template:


### PR DESCRIPTION
## Détails

- Génère un environnement Molecule par défaut
- Utilise une image Docker de Geerlinguy afin de faire fonctioner systemd
- Teste l'installation d'une application Flask

## Pourquoi

Avoir la correction pour Molecule aussi après le TP3.
Note : le test d'idempotence échoue à cause de systemd qui redémarre le service.

:warning: Cette branche ne doit pas être fusionnée mais ajoutée en tant que branche `tp3_correction_molecule`